### PR TITLE
fix: Remove `docker compose` commands from deploy script

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,12 +35,6 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build Docker image
-        run: docker compose build
-
-      - name: Push Docker image
-        run: docker compose push
-
-      - name: Build Docker image
         run: |
           docker build -t ${{ secrets.USER_SERVICE_NAME }}:${{ env.VERSION }} ./src
 


### PR DESCRIPTION
Closes #14 

This is a bit annoying. I shouldn't publish to DockerHub before a PR is merged, but if the publish script itself is flawed, I have to make new issues, branches and PRs again.