### PR TITLE
Kaniko

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,21 +32,17 @@ jobs:
 
       - name: Set VERSION environment variable
         run: echo "VERSION=${{ steps.version.outputs.version }}" >> $GITHUB_ENV
-
-      - name: Log in to DockerHub
-        uses: docker/login-action@v2
+  
+      - name: Build and push Docker image using Kaniko
+        uses: aevea/action-kaniko@master
         with:
+          image: ${{ secrets.USER_SERVICE_NAME }}
+          tag: ${{ env.VERSION }}
+          path: ./src/
+          build_file: Dockerfile
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Build Docker image
-        run: |
-          docker build -t ${{ secrets.USER_SERVICE_NAME }}:${{ env.VERSION }} ./src
-
-      - name: Push Docker image
-        run: |
-          docker push ${{ secrets.USER_SERVICE_NAME }}:${{ env.VERSION }}
-          
       - name: Push tag
         run: |
           git config user.name "github-actions"


### PR DESCRIPTION
Closes #35 

Kaniko is used to build and push docker images inside a Docker context or inside Kubernetes. I guess the idea is that it's safer since it's in user space. Kaniko is no longer maintained, but the project spec asks us to use it, so here it is.

Once this is merged into `develop` and we confirm that it works correctly, I'll create the PRs for the remaining services (room-service, reservation-service, web-app).

I've also tested it in a [sandbox repo](https://github.com/magley/ci-cd-publish-test).