### PR TITLE
Feature sonarqube

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -3,9 +3,11 @@ name: Sonarqube Analysis
 on:
   push:
     branches:
+      - feature-sonarqube # Temporary
+  pull_request:
+    branches:
       - master
       - develop
-      - feature-sonarqube # Temporary
 
 jobs:
   sonarqube:

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -1,0 +1,37 @@
+name: Sonarqube Analysis
+
+on:
+  push:
+    branches:
+      - master
+      - develop
+      - feature-sonarqube # Temporary
+
+jobs:
+  sonarqube:
+    name: SonarQube
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.24
+
+      - name: Cache Go modules
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: SonarQube Scan
+        uses: SonarSource/sonarqube-scan-action@v6
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,14 @@
+sonar.projectKey=book-em_user-service
+sonar.organization=book-em
+
+
+# This is the name and version displayed in the SonarCloud UI.
+sonar.projectName=user-service
+sonar.projectVersion=1.0
+
+
+# Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
+sonar.sources=.
+
+# Encoding of the source code. Default is default system encoding
+#sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
Closes #39

---

My process of adding SonarQube analysis:

- created a free account on SonarCloud, connected through my GitHub account
- added an organization matching `book-em`
- created a repository for `user-service`
- created a sonar key
- added a github action and the properties file

It fails a lot because branch analysis works only on the main branch (`master`) for Free accounts. As for this PR, it failed initially (Quality Gate wouldn't pass because it found a Security HotSpot within the sonarqube workflow file, but I manually makred it as safe and then it passed):

<img width="1551" height="737" alt="image" src="https://github.com/user-attachments/assets/4310bedf-da5c-4647-80e9-fb8140643d52" />

Obviously that's not what you're supposed to do, but the project spec only requires us to have code analysis on one microservice, so here it is.